### PR TITLE
Correct conflicting value forms in the block configuration table

### DIFF
--- a/Specification.pod6
+++ b/Specification.pod6
@@ -16,6 +16,11 @@ This file is deliberately specified in Podlite format
 
 =begin CHANGES
 
+=head2 Unreleased
+
+=head3 Changed:
+    =item Corrected conflicting value forms in the block configuration table.
+
 =head2 v2.0
 
 =head3 Added:
@@ -190,8 +195,8 @@ any of:
 =for table :nested :caption("Block configuration syntax") :id<configuration_syntax>
  Value is...              Specify with...              Or with...                   Also valid
  ======================   ==========================   ==========================   ==============
- Boolean (true)           C«:key»                      C«:key(1)»
- Boolean (false)          C«:!key»                     C«:key(0)»
+ Boolean (true)           C«:key»
+ Boolean (false)          C«:!key»
  Integer                  C«:key(N)»
  String (single word)     C«:key<str>»                 C«:key('str')»               C«:key'str'» C«:key｢str｣» C«:key"str"»
  String (with spaces)     C«:key('str with spaces')»   C«:key("str with spaces")»   C«:key'str with spaces'» C«:key｢str with spaces｣» C«:key"str with spaces"»


### PR DESCRIPTION
The configuration table gave parenthesised digits two readings at once,
boolean and integer, so `:key(1)` fell under both.

Booleans are already written with the bare and negated forms, `:key` and
`:!key`, which the same table lists. The parenthesised cells added nothing
and only produced the overlap, so they are dropped.

Also opens an `Unreleased` section in `=CHANGES` for the next release cycle.

Refs #29
