### PR TITLE
Use square brackets in :columns examples

### DIFF
--- a/Specification.pod6
+++ b/Specification.pod6
@@ -1781,7 +1781,7 @@ option, as in:
 
 =begin code
   =for data-table :src<file:./planets.csv>
-  =    :columns<name,radius_km>
+  =    :columns[name,radius_km]
   =    :caption('Inner planets')
 =end code
 
@@ -1793,7 +1793,7 @@ The reference form refers to a named C<=data> block:
     Q1,EU,120
   =end data
 
-  =for data-table :src<data:sales> :columns<quarter,revenue>
+  =for data-table :src<data:sales> :columns[quarter,revenue]
 =end code
 
 The body is verbatim and is parsed per C<:mime-type> using RFC 4180
@@ -1854,9 +1854,9 @@ column position (1-based) in the source, not row position. For
 example:
 
 =begin code
-  :columns<product,revenue>
-  :columns<1,3,5>
-  :columns<revenue,product>
+  :columns[product,revenue]
+  :columns[1,3,5]
+  :columns[revenue,product]
 =end code
 
 Output order matches list order; columns absent from the list are


### PR DESCRIPTION
The `:columns` examples used a comma inside angle brackets. A comma there is
part of the value, so the examples described a string that the block splits,
not a list. Square brackets make them lists at the language level.

Documents written the old way keep working: the block still splits a
comma-separated string.
