### PR TITLE
Rework attribute value rules and forms

### DIFF
--- a/Specification.pod6
+++ b/Specification.pod6
@@ -18,12 +18,7 @@ This file is deliberately specified in Podlite format
 
 =head2 Unreleased
 
-=head3 Added:
-    =item Rules for reading attribute values.
-
 =head3 Changed:
-    =item Corrected conflicting value forms in the block configuration table.
-    =item Extended the block configuration table to the forms the parser accepts.
     =item Reworked the forms of an attribute value.
 
 =head2 v2.0

--- a/Specification.pod6
+++ b/Specification.pod6
@@ -24,6 +24,7 @@ This file is deliberately specified in Podlite format
 =head3 Changed:
     =item Corrected conflicting value forms in the block configuration table.
     =item Extended the block configuration table to the forms the parser accepts.
+    =item Reworked the forms of an attribute value.
 
 =head2 v2.0
 
@@ -197,35 +198,36 @@ different ways by different types of blocks, but is always specified using
 any of:
 
 =for table :nested :caption("Block configuration syntax") :id<configuration_syntax>
- Value is...              Specify with...              Or with...                   Also valid
- ======================   ==========================   ==========================   ==============
- Boolean (true)           C«:key»
- Boolean (false)          C«:!key»
+ Value                    Written as                   Also accepted
+ ======================   ==========================   ==========================================
+ Boolean                  C«:key» C«:!key»             C«:key(True)» C«:key(False)»
  Number                   C«:key(42)»                  C«:key(2.3)»
- String (single word)     C«:key<str>»                 C«:key('str')»               C«:key'str'» C«:key｢str｣» C«:key"str"»
- String (with spaces)     C«:key('str with spaces')»   C«:key("str with spaces")»   C«:key'str with spaces'» C«:key｢str with spaces｣» C«:key"str with spaces"»
- List                     C«:key<val1 val2>»           C«:key[val1,val2]»           C«:key(val1, val2)»
- Hash                     C«:key{a=>1, b=>2}»
+ String                   C«:key<str>»                 C«:key('str')» C«:key"str"» C«:key'str'» C«:key｢str｣»
+ String with spaces       C«:key('str with spaces')»   C«:key("str with spaces")» C«:key'str with spaces'» C«:key｢str with spaces｣»
+ List                     C«:key<a b>»                 C«:key('a','b')»
+ Hash                     C«:key{:a<x>, :b(42), :c}»   C«:key{a=>1, b=>'str', c=>True}»
+ Hash with numeric keys   C«:key{1=>'x', 2=>'y'}»
 
-All option keys and values must, of course, be constants since Podlite is a
-specification language, not a programming language. Specifically, option
-values cannot be closures.
+All option keys and values are constants: Podlite is a specification
+language, not a programming language. An option value cannot be a closure.
 
-The way a value is read is determined by the delimiters that enclose it.
-Square brackets always denote a list, whatever the number of elements, while
-parentheses denote a single value and denote a list only when the elements are
-separated by commas. Whitespace surrounding a value is not significant and is
-removed before the value is read.
+Whitespace surrounding a value is not significant and is removed. The
+delimiters that enclose a value determine how it is read.
 
-Text enclosed in angle brackets is not converted to another type, so
-C<< :key<1> >> is read as the string C<1> rather than as a number. Whitespace
-inside angle brackets separates the content into a list, which makes
-C<< :key<a b> >> a list of two elements. A comma is retained as part of the
-value, so C<< :key<a,b> >> is read as the string C<a,b>. Quotation marks inside
-angle brackets delimit a string and suppress that separation. A quoted value is
-read as a string even when it holds a single word or nothing at all.
-C<< :key<'a b'> >>, C<< :key<'a'> >> and C<< :key<''> >> are therefore all
-strings.
+A single word enclosed in angle brackets is not converted to another type. A
+comma is retained as part of the value, so C<< :key<a,b> >> is read as the
+string C<a,b>. Quotation marks delimit a string and suppress separation by
+whitespace, which makes C<< :key<'a b'> >> a string. Guillemets are not
+quotation marks and are retained as part of the value.
+
+Apart from C<True> and C<False>, an unquoted word is not a valid element of a
+parenthesised list or value of a hash entry. Inside braces an option is read
+as on the marker line: with no value it denotes the boolean true, and negated
+it denotes the boolean false. The key of an option is an identifier.
+
+A value that cannot be read is discarded together with its attribute, and
+parsing of the block continues. Podlite parsers issue a warning that
+identifies the position of the discarded value.
 
 The configuration section may be extended over subsequent lines by
 starting those lines with an C<=> in the first (virtual) column followed
@@ -1876,8 +1878,8 @@ The value is a hash mapping source identifiers, either names or
 indices, to display strings. For example:
 
 =begin code
-  :rename{revenue=>USD}
-  :rename{1=>Time, 2=>Action}
+  :rename{revenue=>'USD'}
+  :rename{1=>'Time', 2=>'Action'}
   :rename{product=>'Product name'}
 =end code
 

--- a/Specification.pod6
+++ b/Specification.pod6
@@ -1855,7 +1855,7 @@ example:
 
 =begin code
   :columns<product revenue>
-  :columns[1,3,5]
+  :columns(1,3,5)
   :columns<revenue product>
 =end code
 
@@ -2216,7 +2216,7 @@ The C<:folded-levels> attribute indicates which levels of the TOC should
 be folded. 
 
 =begin code :allow<B>
- =for toc B<:folded-levels[2,3]> :caption('Table of contents')
+ =for toc B<:folded-levels(2,3)> :caption('Table of contents')
     head1, head2, item1
 =end code
 


### PR DESCRIPTION
The forms of an attribute value and the rules for reading them are reworked.

The configuration table gives one recommended form per value kind; the prose
states only the rules the table cannot show.
